### PR TITLE
Deprecation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2025-01-27
+
+### Fixed
+
+- `validates_international` uniqueness validation now uses `i18n_where` instead of deprecated `international` method
+  - Eliminates deprecation warnings when using `validates_international :attr, uniqueness: true`
+
 ## [0.5.0] - 2025-12-03
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    internationalize (0.5.0)
+    internationalize (0.5.1)
       activerecord (>= 7.0)
       activesupport (>= 7.0)
 

--- a/lib/internationalize/validations.rb
+++ b/lib/internationalize/validations.rb
@@ -72,7 +72,7 @@ module Internationalize
           value = record.send("#{attr}_#{locale}")
           next if value.blank?
 
-          scope = record.class.international(attr => value, locale: locale)
+          scope = record.class.i18n_where(attr => value, locale: locale)
           scope = scope.where.not(id: record.id) if record.persisted?
 
           if scope.exists?

--- a/lib/internationalize/version.rb
+++ b/lib/internationalize/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Internationalize
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
This pull request addresses a deprecation warning in the uniqueness validation logic and prepares a new patch release. The main change is updating the uniqueness validation to use the current `i18n_where` method instead of the deprecated `international` method, ensuring compatibility and removing warnings. The version is also bumped for release.

Bug fix:

* Updated the uniqueness validation in `validate_international_uniqueness` to use `i18n_where` instead of the deprecated `international` method, eliminating deprecation warnings when using `validates_international :attr, uniqueness: true` (`lib/internationalize/validations.rb`).

Release management:

* Bumped the gem version to `0.5.1` in `lib/internationalize/version.rb`.
* Added a changelog entry for version `0.5.1`, documenting the fix for the uniqueness validation deprecation warning (`CHANGELOG.md`).